### PR TITLE
Small tests refactoring

### DIFF
--- a/storage/clickhousespanstore/mocks/db.go
+++ b/storage/clickhousespanstore/mocks/db.go
@@ -1,0 +1,14 @@
+package mocks
+
+import (
+	"database/sql"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func GetDbMock() (*sql.DB, sqlmock.Sqlmock, error) {
+	return sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+		sqlmock.ValueConverterOption(ConverterMock{}),
+	)
+}

--- a/storage/clickhousespanstore/reader_test.go
+++ b/storage/clickhousespanstore/reader_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore/mocks"
+
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gogo/protobuf/proto"
 	"github.com/jaegertracing/jaeger/model"
@@ -30,7 +32,7 @@ const (
 var testStartTime = time.Date(2010, 3, 15, 7, 40, 0, 0, time.UTC)
 
 func TestTraceReader_FindTraceIDs(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -109,7 +111,7 @@ func TestTraceReader_FindTraceIDs(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceIDsShortDurationAfterReduction(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -192,7 +194,7 @@ func TestTraceReader_FindTraceIDsShortDurationAfterReduction(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceIDsEarlyExit(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -245,7 +247,7 @@ func TestTraceReader_FindTraceIDsEarlyExit(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceIDsShortRange(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -288,7 +290,7 @@ func TestTraceReader_FindTraceIDsShortRange(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceIDsQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -327,7 +329,7 @@ func TestTraceReader_FindTraceIDsQueryError(t *testing.T) {
 }
 
 func TestTraceReader_FindTraceIDsZeroStartTime(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -349,7 +351,7 @@ func TestTraceReader_FindTraceIDsZeroStartTime(t *testing.T) {
 }
 
 func TestTraceReader_GetServices(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -372,7 +374,7 @@ func TestTraceReader_GetServices(t *testing.T) {
 }
 
 func TestTraceReader_GetServicesQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -388,7 +390,7 @@ func TestTraceReader_GetServicesQueryError(t *testing.T) {
 }
 
 func TestTraceReader_GetServicesNoTable(t *testing.T) {
-	db, _, err := getDbMock()
+	db, _, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -400,7 +402,7 @@ func TestTraceReader_GetServicesNoTable(t *testing.T) {
 }
 
 func TestTraceReader_GetOperations(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -427,7 +429,7 @@ func TestTraceReader_GetOperations(t *testing.T) {
 }
 
 func TestTraceReader_GetOperationsQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -446,7 +448,7 @@ func TestTraceReader_GetOperationsQueryError(t *testing.T) {
 }
 
 func TestTraceReader_GetOperationsNoTable(t *testing.T) {
-	db, _, err := getDbMock()
+	db, _, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -459,7 +461,7 @@ func TestTraceReader_GetOperationsNoTable(t *testing.T) {
 }
 
 func TestTraceReader_GetTrace(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -527,7 +529,7 @@ func TestTraceReader_GetTrace(t *testing.T) {
 }
 
 func TestSpanWriter_getTraces(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -591,7 +593,7 @@ func TestSpanWriter_getTraces(t *testing.T) {
 }
 
 func TestSpanWriter_getTracesIncorrectData(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -653,7 +655,7 @@ func TestSpanWriter_getTracesIncorrectData(t *testing.T) {
 }
 
 func TestSpanWriter_getTracesQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -684,7 +686,7 @@ func TestSpanWriter_getTracesQueryError(t *testing.T) {
 }
 
 func TestSpanWriter_getTracesRowsScanError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -716,7 +718,7 @@ func TestSpanWriter_getTracesRowsScanError(t *testing.T) {
 }
 
 func TestSpanWriter_getTraceNoTraceIDs(t *testing.T) {
-	db, _, err := getDbMock()
+	db, _, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -766,7 +768,7 @@ func getTracesFromSpans(spans []model.Span) []*model.Trace {
 }
 
 func TestSpanWriter_findTraceIDsInRange(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -927,7 +929,7 @@ func TestSpanWriter_findTraceIDsInRange(t *testing.T) {
 }
 
 func TestSpanReader_findTraceIDsInRangeNoIndexTable(t *testing.T) {
-	db, _, err := getDbMock()
+	db, _, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -944,7 +946,7 @@ func TestSpanReader_findTraceIDsInRangeNoIndexTable(t *testing.T) {
 }
 
 func TestSpanReader_findTraceIDsInRangeEndBeforeStart(t *testing.T) {
-	db, _, err := getDbMock()
+	db, _, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -961,7 +963,7 @@ func TestSpanReader_findTraceIDsInRangeEndBeforeStart(t *testing.T) {
 }
 
 func TestSpanReader_findTraceIDsInRangeQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -995,7 +997,7 @@ func TestSpanReader_findTraceIDsInRangeQueryError(t *testing.T) {
 }
 
 func TestSpanReader_findTraceIDsInRangeIncorrectData(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -1038,7 +1040,7 @@ func TestSpanReader_findTraceIDsInRangeIncorrectData(t *testing.T) {
 }
 
 func TestSpanReader_getStrings(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -1062,7 +1064,7 @@ func TestSpanReader_getStrings(t *testing.T) {
 }
 
 func TestSpanReader_getStringsQueryError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 
@@ -1080,7 +1082,7 @@ func TestSpanReader_getStringsQueryError(t *testing.T) {
 }
 
 func TestSpanReader_getStringsRowError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err, "an error was not expected when opening a stub database connection")
 	defer db.Close()
 

--- a/storage/clickhousespanstore/writer_test.go
+++ b/storage/clickhousespanstore/writer_test.go
@@ -182,7 +182,7 @@ func TestSpanWriter_General(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			db, mock, err := getDbMock()
+			db, mock, err := mocks.GetDbMock()
 			require.NoError(t, err, "an error was not expected when opening a stub database connection")
 			defer db.Close()
 
@@ -220,7 +220,7 @@ func TestSpanWriter_BeginError(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			db, mock, err := getDbMock()
+			db, mock, err := mocks.GetDbMock()
 			require.NoError(t, err, "an error was not expected when opening a stub database connection")
 			defer db.Close()
 
@@ -263,7 +263,7 @@ func TestSpanWriter_PrepareError(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			db, mock, err := getDbMock()
+			db, mock, err := mocks.GetDbMock()
 			require.NoError(t, err, "an error was not expected when opening a stub database connection")
 			defer db.Close()
 
@@ -317,7 +317,7 @@ func TestSpanWriter_ExecError(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			db, mock, err := getDbMock()
+			db, mock, err := mocks.GetDbMock()
 			require.NoError(t, err, "an error was not expected when opening a stub database connection")
 			defer db.Close()
 
@@ -343,13 +343,6 @@ func TestSpanWriter_ExecError(t *testing.T) {
 			spyLogger.AssertLogsOfLevelEqual(t, hclog.Debug, test.expectedLogs)
 		})
 	}
-}
-
-func getDbMock() (*sql.DB, sqlmock.Sqlmock, error) {
-	return sqlmock.New(
-		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
-		sqlmock.ValueConverterOption(mocks.ConverterMock{}),
-	)
 }
 
 func getSpanWriter(spyLogger mocks.SpyLogger, db *sql.DB, encoding Encoding, indexTable TableName) *SpanWriter {

--- a/storage/store_test.go
+++ b/storage/store_test.go
@@ -62,7 +62,7 @@ func TestStore_DependencyReader(t *testing.T) {
 }
 
 func TestStore_Close(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -112,7 +112,7 @@ func newStore(db *sql.DB, logger mocks.SpyLogger) Store {
 }
 
 func TestStore_executeScripts(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -140,7 +140,7 @@ func TestStore_executeScripts(t *testing.T) {
 }
 
 func TestStore_executeScriptsExecuteError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -163,7 +163,7 @@ func TestStore_executeScriptsExecuteError(t *testing.T) {
 }
 
 func TestStore_executeScriptBeginError(t *testing.T) {
-	db, mock, err := getDbMock()
+	db, mock, err := mocks.GetDbMock()
 	require.NoError(t, err)
 	defer db.Close()
 
@@ -176,11 +176,4 @@ func TestStore_executeScriptBeginError(t *testing.T) {
 	mock.ExpectBegin().WillReturnError(errorMock)
 	err = executeScripts(spyLogger, scripts, db)
 	assert.EqualError(t, err, errorMock.Error())
-}
-
-func getDbMock() (*sql.DB, sqlmock.Sqlmock, error) {
-	return sqlmock.New(
-		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
-		sqlmock.ValueConverterOption(mocks.ConverterMock{}),
-	)
 }


### PR DESCRIPTION
Moved duplicated methods getDbMock from clickhousespanstore and store packages to single method in mock package.

Signed-off-by: Yury Frolov <yura200253@gmail.com>
