### PR TITLE
Retrieve operations from ClickHouse sorted

### DIFF
--- a/storage/clickhousespanstore/reader.go
+++ b/storage/clickhousespanstore/reader.go
@@ -191,7 +191,7 @@ func (r *TraceReader) GetOperations(
 	}
 
 	//nolint:gosec  , G201: SQL string formatting
-	query := fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind", r.operationsTable)
+	query := fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind ORDER BY operation", r.operationsTable)
 	args := []interface{}{params.ServiceName}
 
 	span.SetTag("db.statement", query)

--- a/storage/clickhousespanstore/reader_test.go
+++ b/storage/clickhousespanstore/reader_test.go
@@ -420,7 +420,7 @@ func TestTraceReader_GetOperations(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			mock.
-				ExpectQuery(fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind", testOperationsTable)).
+				ExpectQuery(fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind ORDER BY operation", testOperationsTable)).
 				WithArgs(service).
 				WillReturnRows(test.rows)
 
@@ -441,7 +441,7 @@ func TestTraceReader_GetOperationsQueryError(t *testing.T) {
 	service := "test service"
 	params := spanstore.OperationQueryParameters{ServiceName: service}
 	mock.
-		ExpectQuery(fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind", testOperationsTable)).
+		ExpectQuery(fmt.Sprintf("SELECT operation, spankind FROM %s WHERE service = ? GROUP BY operation, spankind ORDER BY operation", testOperationsTable)).
 		WithArgs(service).
 		WillReturnError(errorMock)
 


### PR DESCRIPTION
## Which problem is this PR solving?
- Resolves #90 

## Short description of the changes
- Now operations are retrieved from ClickHouse sorted by name.
