### PR TITLE
Separate multiple values of same tag with comma

### DIFF
--- a/storage/clickhousespanstore/reader.go
+++ b/storage/clickhousespanstore/reader.go
@@ -341,7 +341,7 @@ func (r *TraceReader) findTraceIDsInRange(ctx context.Context, params *spanstore
 	}
 
 	for key, value := range params.Tags {
-		query += " AND has(tags.key, ?) AND tags.value[indexOf(tags.key, ?)] == ?"
+		query += " AND has(tags.key, ?) AND has(splitByChar(',', tags.value[indexOf(tags.key, ?)]), ?)"
 		args = append(args, key, key, value)
 	}
 

--- a/storage/clickhousespanstore/reader_test.go
+++ b/storage/clickhousespanstore/reader_test.go
@@ -864,7 +864,7 @@ func TestSpanWriter_findTraceIDsInRange(t *testing.T) {
 			expectedQuery: fmt.Sprintf(
 				"SELECT DISTINCT traceID FROM %s WHERE service = ? AND timestamp >= ? AND timestamp <= ?%s ORDER BY service, timestamp DESC LIMIT ?",
 				testIndexTable,
-				strings.Repeat(" AND has(tags.key, ?) AND tags.value[indexOf(tags.key, ?)] == ?", len(tags)),
+				strings.Repeat(" AND has(tags.key, ?) AND has(splitByChar(',', tags.value[indexOf(tags.key, ?)]), ?)", len(tags)),
 			),
 			expectedArgs: []driver.Value{
 				service,

--- a/storage/clickhousespanstore/worker_test.go
+++ b/storage/clickhousespanstore/worker_test.go
@@ -65,21 +65,21 @@ var (
 	writeBatchLogs = []mocks.LogMock{{Msg: "Writing spans", Args: []interface{}{"size", len(testSpans)}}}
 )
 
-func TestSpanWriter_TagString(t *testing.T) {
+func TestSpanWriter_TagKeyValue(t *testing.T) {
 	tests := map[string]struct {
 		kv       model.KeyValue
 		expected string
 	}{
-		"string value":       {kv: model.String("tag_key", "tag_string_value"), expected: "tag_key=tag_string_value"},
-		"true value":         {kv: model.Bool("tag_key", true), expected: "tag_key=true"},
-		"false value":        {kv: model.Bool("tag_key", false), expected: "tag_key=false"},
-		"positive int value": {kv: model.Int64("tag_key", 1203912), expected: "tag_key=1203912"},
-		"negative int value": {kv: model.Int64("tag_key", -1203912), expected: "tag_key=-1203912"},
-		"float value":        {kv: model.Float64("tag_key", 0.005009), expected: "tag_key=0.005009"},
+		"string value":       {kv: model.String("tag_key", "tag_string_value"), expected: "tag_string_value"},
+		"true value":         {kv: model.Bool("tag_key", true), expected: "true"},
+		"false value":        {kv: model.Bool("tag_key", false), expected: "false"},
+		"positive int value": {kv: model.Int64("tag_key", 1203912), expected: "1203912"},
+		"negative int value": {kv: model.Int64("tag_key", -1203912), expected: "-1203912"},
+		"float value":        {kv: model.Float64("tag_key", 0.005009), expected: "0.005009"},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, test.expected, tagString(&test.kv), "Incorrect tag string")
+			assert.Equal(t, test.expected, tagValue(&test.kv), "Incorrect tag value string")
 		})
 	}
 }
@@ -110,8 +110,8 @@ func TestSpanWriter_UniqueTagsForSpan(t *testing.T) {
 			tags:           []model.KeyValue{model.String("key2", "value_a"), model.String("key2", "value_b")},
 			processTags:    []model.KeyValue{model.Int64("key3", 412)},
 			logs:           []model.Log{{Fields: []model.KeyValue{model.Float64("key1", .5)}}},
-			expectedKeys:   []string{"key1", "key2", "key2", "key3"},
-			expectedValues: []string{"0.5", "value_a", "value_b", "412"},
+			expectedKeys:   []string{"key1", "key2", "key3"},
+			expectedValues: []string{"0.5", "value_a,value_b", "412"},
 		},
 		"repeating values": {
 			tags:           []model.KeyValue{model.String("key2", "value"), model.Int64("key4", 412)},


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #98 

## Short description of the changes
Store multiple different values of the same tag in a single key separated by comma. It allows us to find trace by any of the tag value (not only first one).

PROS:
1. Ability to search any tag value
2. Backward compability (no schema changes or update required). 

CONS:
1. Search for tag value containing comma will be incorrect (could be solved by parametrizing separator)