### PR TITLE
Fix panic when max_span_count is reached, add counter metric

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,11 @@
 address: tcp://some-clickhouse-server:9000
 # When empty the embedded scripts from sqlscripts directory are used
 init_sql_scripts_dir:
-# Maximal amount of spans that can be written at the same time. Default 10_000_000
+# Maximal amount of spans that can be pending writes at a time.
+# New spans exceeding this limit will be discarded,
+# keeping memory in check if there are issues writing to ClickHouse.
+# Check the "jaeger_clickhouse_discarded_spans" metric to keep track of discards.
+# If 0, no limit is set. Default 10_000_000.
 max_span_count:
 # Batch write size. Default 10_000.
 batch_write_size:
@@ -11,13 +15,13 @@ batch_flush_interval:
 encoding:
 # Path to CA TLS certificate.
 ca_file:
-# Username for connection. Default is "default".
+# Username for connection to ClickHouse. Default is "default".
 username:
-# Password for connection.
+# Password for connection to ClickHouse.
 password:
-# Database name. The database has to be created manually before Jaeger starts. Default is "default".
+# ClickHouse database name. The database must be created manually before Jaeger starts. Default is "default".
 database:
-# Endpoint for scraping prometheus metrics. Default localhost:9090.
+# Endpoint for serving prometheus metrics. Default localhost:9090.
 metrics_endpoint: localhost:9090
 # Whether to use sql scripts supporting replication and sharding.
 # Replication can be used only on database with Atomic engine.
@@ -31,5 +35,5 @@ spans_index_table:
 operations_table:
 # TTL for data in tables in days. If 0, no TTL is set. Default 0.
 ttl:
-# The maximum number of spans to fetch per trace. If 0, no limits is set. Default 0.
+# The maximum number of spans to fetch per trace. If 0, no limit is set. Default 0.
 max_num_spans:

--- a/storage/clickhousespanstore/pool.go
+++ b/storage/clickhousespanstore/pool.go
@@ -59,7 +59,7 @@ func NewWorkerPool(params *WriteParams, maxSpanCount int) WriteWorkerPool {
 
 func (pool *WriteWorkerPool) Work() {
 	finish := false
-	nextWorkerId := int32(1)
+	nextWorkerID := int32(1)
 	pendingSpanCount := 0
 	for {
 		// Initialize to zero, or update value from previous loop
@@ -72,7 +72,7 @@ func (pool *WriteWorkerPool) Work() {
 			if pool.checkLimit(pendingSpanCount, batchSize) {
 				// Limit disabled or batch fits within limit, write the batch.
 				worker := WriteWorker{
-					workerId: nextWorkerId,
+					workerID: nextWorkerID,
 
 					params: pool.params,
 					batch:  batch,
@@ -81,10 +81,10 @@ func (pool *WriteWorkerPool) Work() {
 					workerDone: pool.workerDone,
 					done:       sync.WaitGroup{},
 				}
-				if nextWorkerId == math.MaxInt32 {
-					nextWorkerId = 1
+				if nextWorkerID == math.MaxInt32 {
+					nextWorkerID = 1
 				} else {
-					nextWorkerId++
+					nextWorkerID++
 				}
 				pool.workers.AddWorker(&worker)
 				pendingSpanCount += batchSize

--- a/storage/clickhousespanstore/worker.go
+++ b/storage/clickhousespanstore/worker.go
@@ -19,6 +19,8 @@ var delays = []int{2, 3, 5, 8}
 // Given a batch of spans, WriteWorker attempts to write them to database.
 // Interval in seconds between attempts changes due to delays slice, then it remains the same as the last value in delays.
 type WriteWorker struct {
+	workerId int32
+
 	params *WriteParams
 	batch  []*model.Span
 
@@ -34,7 +36,7 @@ func (worker *WriteWorker) Work() {
 
 	// TODO: look for specific error(connection refused | database error)
 	if err := worker.writeBatch(worker.batch); err != nil {
-		worker.params.logger.Error("Could not write a batch of spans", "error", err)
+		worker.params.logger.Error("Could not write a batch of spans", "error", err, "worker_id", worker.workerId)
 	} else {
 		worker.close(len(worker.batch))
 		return
@@ -49,7 +51,7 @@ func (worker *WriteWorker) Work() {
 			return
 		case <-timer:
 			if err := worker.writeBatch(worker.batch); err != nil {
-				worker.params.logger.Error("Could not write a batch of spans", "error", err)
+				worker.params.logger.Error("Could not write a batch of spans", "error", err, "worker_id", worker.workerId)
 			} else {
 				worker.close(len(worker.batch))
 				return

--- a/storage/clickhousespanstore/writer.go
+++ b/storage/clickhousespanstore/writer.go
@@ -43,7 +43,7 @@ type SpanWriter struct {
 	done   sync.WaitGroup
 }
 
-var registerMetrics sync.Once
+var registerWriterMetrics sync.Once
 var _ spanstore.Writer = (*SpanWriter)(nil)
 
 // NewSpanWriter returns a SpanWriter for the database
@@ -78,7 +78,7 @@ func NewSpanWriter(
 }
 
 func (w *SpanWriter) registerMetrics() {
-	registerMetrics.Do(func() {
+	registerWriterMetrics.Do(func() {
 		prometheus.MustRegister(numWritesWithBatchSize)
 		prometheus.MustRegister(numWritesWithFlushInterval)
 	})

--- a/storage/config.go
+++ b/storage/config.go
@@ -30,7 +30,11 @@ type Configuration struct {
 	BatchWriteSize int64 `yaml:"batch_write_size"`
 	// Batch flush interval. Default is 5s.
 	BatchFlushInterval time.Duration `yaml:"batch_flush_interval"`
-	// Maximal amount of spans that can be written at the same time. Default is 10_000_000.
+	// Maximal amount of spans that can be pending writes at a time.
+	// New spans exceeding this limit will be discarded,
+	// keeping memory in check if there are issues writing to ClickHouse.
+	// Check the "jaeger_clickhouse_discarded_spans" metric to keep track of discards.
+	// Default 10_000_000, or disable the limit entirely by setting to 0.
 	MaxSpanCount int `yaml:"max_span_count"`
 	// Encoding either json or protobuf. Default is json.
 	Encoding EncodingType `yaml:"encoding"`


### PR DESCRIPTION
Panic seen in `ghcr.io/jaegertracing/jaeger-clickhouse:0.8.0` with `log-level=debug`:
```
panic: undefined type *clickhousespanstore.WriteWorker return from workerHeap

goroutine 20 [running]:
github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore.(*WriteWorkerPool).CleanWorkers(0xc00020c300, 0xc00008eefc)
	github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore/pool.go:95 +0x199
github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore.(*WriteWorkerPool).Work(0xc00020c300)
	github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore/pool.go:50 +0x15e
created by github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore.(*SpanWriter).backgroundWriter
	github.com/jaegertracing/jaeger-clickhouse/storage/clickhousespanstore/writer.go:89 +0x226
```

Also adds metric counter and logging to surface when things are hitting backpressure.

Signed-off-by: Nick Parker <nparker@gitlab.com>

<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
- Fixes panic when recently added max_span_count flush is being exercised

## Short description of the changes
- Updates case type so that the panic no longer occurs
- Adds debug log and metric counter to allow monitoring of the setting, since reaching the limit may indicate backpressure/problems with writing spans to ClickHouse. (In my case I was seeing the panic when ClickHouse's disk was full)