### PR TITLE
upgraded net and sys to fix CVE-2022-27664

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,8 +90,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.9.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
-	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
+	golang.org/x/net v0.0.0-20221002022538-bcab6841153b // indirect
+	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac // indirect
 	google.golang.org/grpc v1.46.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -833,6 +833,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20221002022538-bcab6841153b h1:6e93nYa3hNqAvLr0pD4PN1fFS+gKzp2zAXqrnTCstqU=
+golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -938,6 +940,8 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
+golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
## Which problem is this PR solving?
Upgrades the net and sys dependencies to mitigate  [CVE-2022-27664](https://avd.aquasec.com/nvd/2022/cve-2022-27664/)

Latest version was failing image scans:
```
$ trivy i ghcr.io/jaegertracing/jaeger-clickhouse:0.12.0
2022-10-03T12:28:47.370-0400    INFO    Detected OS: alpine
2022-10-03T12:28:47.370-0400    INFO    This OS version is not on the EOL list: alpine 3.16
2022-10-03T12:28:47.370-0400    INFO    Detecting Alpine vulnerabilities...
2022-10-03T12:28:47.371-0400    INFO    Number of language-specific files: 1
2022-10-03T12:28:47.371-0400    INFO    Detecting gobinary vulnerabilities...

ghcr.io/jaegertracing/jaeger-clickhouse:0.12.0 (alpine 3.16.2)
==============================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


go/bin/jaeger-clickhouse (gobinary)
===================================
Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 1, CRITICAL: 0)

+------------------+------------------+----------+------------------------------------+-----------------------------------+---------------------------------------+
|     LIBRARY      | VULNERABILITY ID | SEVERITY |         INSTALLED VERSION          |           FIXED VERSION           |                 TITLE                 |
+------------------+------------------+----------+------------------------------------+-----------------------------------+---------------------------------------+
| golang.org/x/net | CVE-2022-27664   | HIGH     | v0.0.0-20220412020605-290c469a71a5 | 0.0.0-20220906165146-f3363e06e74c | golang: net/http: handle server       |
|                  |                  |          |                                    |                                   | errors after sending GOAWAY           |
|                  |                  |          |                                    |                                   | -->avd.aquasec.com/nvd/cve-2022-27664 |
+------------------+------------------+----------+------------------------------------+-----------------------------------+---------------------------------------+
```

## Short description of the changes
Ran 
```
go get -u golang.org/x/net
go get -u golang.org/x/sys
```


Now we get the clean scan:
```
$ trivy i ghcr.io/jaegertracing/jaeger-clickhouse:latest
2022-10-03T12:29:30.017-0400    INFO    Detected OS: alpine
2022-10-03T12:29:30.017-0400    INFO    This OS version is not on the EOL list: alpine 3.16
2022-10-03T12:29:30.017-0400    INFO    Detecting Alpine vulnerabilities...
2022-10-03T12:29:30.021-0400    INFO    Number of language-specific files: 1
2022-10-03T12:29:30.021-0400    INFO    Detecting gobinary vulnerabilities...

ghcr.io/jaegertracing/jaeger-clickhouse:latest (alpine 3.16.2)
==============================================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


go/bin/jaeger-clickhouse (gobinary)
===================================
Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```