### PR TITLE
make connection pool configurable

### DIFF
--- a/storage/config.go
+++ b/storage/config.go
@@ -74,6 +74,14 @@ type Configuration struct {
 	TTLDays uint `yaml:"ttl"`
 	// The maximum number of spans to fetch per trace. If 0, no limits is set. Default 0.
 	MaxNumSpans uint `yaml:"max_num_spans"`
+	// The maximum number of open connections to the database. Default is unlimited (see: https://pkg.go.dev/database/sql#DB.SetMaxOpenConns)
+	MaxOpenConns *uint `yaml:"max_open_conns"`
+	// The maximum number of database connections in the idle connection pool. Default 2. (see: https://pkg.go.dev/database/sql#DB.SetMaxIdleConns)
+	MaxIdleConns *uint `yaml:"max_idle_conns"`
+	// The maximum amount of milliseconds a database connection may be reused. Default = connections are never closed due to age (see: https://pkg.go.dev/database/sql#DB.SetConnMaxLifetime)
+	ConnMaxLifetimeMillis *uint `yaml:"conn_max_lifetime_millis"`
+	// The maximum amount of milliseconds a database connection may be idle. Default = connections are never closed due to idle time (see: https://pkg.go.dev/database/sql#DB.SetConnMaxIdleTime)
+	ConnMaxIdleTimeMillis *uint `yaml:"conn_max_idle_time_millis"`
 }
 
 func (cfg *Configuration) setDefaults() {

--- a/storage/store.go
+++ b/storage/store.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+	"time"
 
 	clickhouse "github.com/ClickHouse/clickhouse-go/v2"
 	hclog "github.com/hashicorp/go-hclog"
@@ -162,6 +163,19 @@ func connector(cfg Configuration) (*sql.DB, error) {
 		}
 	}
 	conn = clickhouse.OpenDB(&options)
+
+	if cfg.MaxOpenConns != nil {
+		conn.SetMaxIdleConns(int(*cfg.MaxOpenConns))
+	}
+	if cfg.MaxIdleConns != nil {
+		conn.SetMaxIdleConns(int(*cfg.MaxIdleConns))
+	}
+	if cfg.ConnMaxLifetimeMillis != nil {
+		conn.SetConnMaxLifetime(time.Millisecond * time.Duration(*cfg.ConnMaxLifetimeMillis))
+	}
+	if cfg.ConnMaxIdleTimeMillis != nil {
+		conn.SetConnMaxIdleTime(time.Millisecond * time.Duration(*cfg.ConnMaxIdleTimeMillis))
+	}
 
 	if err := conn.Ping(); err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: albertlockett <albert.lockett@gmail.com>

## Which problem is this PR solving?
Since the upgrade to 0.12.0 & clickhouse-go v2 have been getting many "broken pipe" errors from the plugin in the jaeger-query application when using a secure (TLS) connection to the DB.

I think what happens is the app starts and the plugin creates the connection to the DB. If no-one uses the jager-query app for a while, the connection can be closed on the DB side and plugin doesnt know.

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/5846846/194430479-c244f067-ddfb-42c9-b425-a21f9227a5b3.png">

the log:
```
{
  "level": "error",
  "ts": 1665095473.535393,
  "caller": "app/http_handler.go:495",
  "msg": "HTTP handler, Internal Server Error",
  "error": "plugin error: rpc error: code = Unknown desc = write: write tcp 127.0.0.1:56049->127.0.0.1:9001: write: broken pipe",
  "stacktrace": "github.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).handleError\n\t/Users/albert.lockett2/Development/jaeger/cmd/query/app/http_handler.go:495\ngithub.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).getServices\n\t/Users/albert.lockett2/Development/jaeger/cmd/query/app/http_handler.go:166\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109\ngithub.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5\n\t/Users/albert.lockett2/go/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go:154\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109\ngithub.com/gorilla/mux.(*Router).ServeHTTP\n\t/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210\ngithub.com/jaegertracing/jaeger/cmd/query/app.additionalHeadersHandler.func1\n\t/Users/albert.lockett2/Development/jaeger/cmd/query/app/additional_headers_handler.go:28\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109\ngithub.com/gorilla/handlers.CompressHandlerLevel.func1\n\t/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/handlers@v1.5.1/compress.go:141\nnet/http.HandlerFunc.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2109\ngithub.com/gorilla/handlers.recoveryHandler.ServeHTTP\n\t/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/handlers@v1.5.1/recovery.go:78\nnet/http.serverHandler.ServeHTTP\n\t/usr/local/opt/go/libexec/src/net/http/server.go:2947\nnet/http.(*conn).serve\n\t/usr/local/opt/go/libexec/src/net/http/server.go:1991"
}
```

the stack:
```
VM75:1 github.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).handleError
	/Users/albert.lockett2/Development/jaeger/cmd/query/app/http_handler.go:495
github.com/jaegertracing/jaeger/cmd/query/app.(*APIHandler).getServices
	/Users/albert.lockett2/Development/jaeger/cmd/query/app/http_handler.go:166
net/http.HandlerFunc.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2109
github.com/opentracing-contrib/go-stdlib/nethttp.MiddlewareFunc.func5
	/Users/albert.lockett2/go/pkg/mod/github.com/opentracing-contrib/go-stdlib@v1.0.0/nethttp/server.go:154
net/http.HandlerFunc.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2109
net/http.HandlerFunc.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2109
github.com/gorilla/mux.(*Router).ServeHTTP
	/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210
github.com/jaegertracing/jaeger/cmd/query/app.additionalHeadersHandler.func1
	/Users/albert.lockett2/Development/jaeger/cmd/query/app/additional_headers_handler.go:28
net/http.HandlerFunc.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2109
github.com/gorilla/handlers.CompressHandlerLevel.func1
	/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/handlers@v1.5.1/compress.go:141
net/http.HandlerFunc.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2109
github.com/gorilla/handlers.recoveryHandler.ServeHTTP
	/Users/albert.lockett2/go/pkg/mod/github.com/gorilla/handlers@v1.5.1/recovery.go:78
net/http.serverHandler.ServeHTTP
	/usr/local/opt/go/libexec/src/net/http/server.go:2947
net/http.(*conn).serve
	/usr/local/opt/go/libexec/src/net/http/server.go:
```

We can use these configuration options to try to reduce the chance that the jaeger-query app uses a connection where the DB closed the socket from its side.

## Short description of the changes
Adds the following configuration options:
- max_open_conns
- max_idle_conns
- conn_max_lifetime_millis
- conn_max_dile_time_millis
