### PR TITLE
Add alter statements for altering table ttl after table creation

### DIFF
--- a/sqlscripts/jaeger-index-alter.tmpl.sql
+++ b/sqlscripts/jaeger-index-alter.tmpl.sql
@@ -1,0 +1,3 @@
+ALTER TABLE {{.SpansIndexTable}}
+{{if .Replication}}ON CLUSTER '{cluster}'{{end}}
+MODIFY {{.TTLTimestamp}}

--- a/sqlscripts/jaeger-spans-alter.tmpl.sql
+++ b/sqlscripts/jaeger-spans-alter.tmpl.sql
@@ -1,0 +1,3 @@
+ALTER TABLE {{.SpansTable}}
+{{if .Replication}}ON CLUSTER '{cluster}'{{end}}
+MODIFY {{.TTLTimestamp}}

--- a/sqlscripts/jaeger-spans-archive-alter.tmpl.sql
+++ b/sqlscripts/jaeger-spans-archive-alter.tmpl.sql
@@ -1,0 +1,3 @@
+ALTER TABLE {{.SpansArchiveTable}}
+{{if .Replication}}ON CLUSTER '{cluster}'{{end}}
+MODIFY {{.TTLTimestamp}}

--- a/storage/store.go
+++ b/storage/store.go
@@ -268,6 +268,12 @@ func runInitScripts(logger hclog.Logger, db *sql.DB, cfg Configuration) error {
 		sqlStatements = append(sqlStatements, render(templates, "jaeger-spans.tmpl.sql", args))
 		sqlStatements = append(sqlStatements, render(templates, "jaeger-spans-archive.tmpl.sql", args))
 
+		if cfg.TTLDays > 0 {
+			sqlStatements = append(sqlStatements, render(templates, "jaeger-index-alter.tmpl.sql", args))
+			sqlStatements = append(sqlStatements, render(templates, "jaeger-spans-alter.tmpl.sql", args))
+			sqlStatements = append(sqlStatements, render(templates, "jaeger-spans-archive-alter.tmpl.sql", args))
+		}
+
 		if cfg.Replication {
 			// Now these tables omit the "_local" suffix
 			distargs := distributedTableArgs{


### PR DESCRIPTION
Signed-off-by: Pradeep Chhetri <pradeepchhetri4444@gmail.com>

Tested in local development environment by updating the ttl field in configuration file.
<!--
Please delete this comment before posting.

We appreciate your contribution to the Jaeger project! 👋🎉

Before creating a pull request, please make sure:
- Your PR is solving one problem
- You have read the guide for contributing
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/jaegertracing/jaeger/blob/master/CONTRIBUTING_GUIDELINES.md#certificate-of-origin---sign-your-work
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
Resolves https://github.com/jaegertracing/jaeger-clickhouse/issues/120

## Short description of the changes
We added alter statements for each of the three tables which gets executed if ttl is greater than 0.
Since materialized views don't support altering ttl configuration, we weren't able to do it for operations table.