### PR TITLE
Switched to DateTime64(UTC) for timestamp

### DIFF
--- a/guide-sharding-and-replication.md
+++ b/guide-sharding-and-replication.md
@@ -86,7 +86,7 @@ CREATE DATABASE IF NOT EXISTS jaeger ON CLUSTER '{cluster}' ENGINE=Atomic;
 USE jaeger;
 
 CREATE TABLE IF NOT EXISTS jaeger_spans_local ON CLUSTER '{cluster}' (
-    timestamp DateTime CODEC(Delta, ZSTD(1)),
+    timestamp DateTime64(3, 'UTC') CODEC(Delta, ZSTD(1)),
     traceID String CODEC(ZSTD(1)),
     model String CODEC(ZSTD(3))
 ) ENGINE ReplicatedMergeTree
@@ -95,7 +95,7 @@ ORDER BY traceID
 SETTINGS index_granularity=1024;
 
 CREATE TABLE IF NOT EXISTS jaeger_index_local ON CLUSTER '{cluster}' (
-    timestamp DateTime CODEC(Delta, ZSTD(1)),
+    timestamp DateTime64(3, 'UTC') CODEC(Delta, ZSTD(1)),
     traceID String CODEC(ZSTD(1)),
     service LowCardinality(String) CODEC(ZSTD(1)),
     operation LowCardinality(String) CODEC(ZSTD(1)),

--- a/sqlscripts/jaeger-index.tmpl.sql
+++ b/sqlscripts/jaeger-index.tmpl.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS {{.SpansIndexTable}}
     {{if .Multitenant -}}
     tenant     LowCardinality(String) CODEC (ZSTD(1)),
     {{- end -}}
-    timestamp  DateTime CODEC (Delta, ZSTD(1)),
+    timestamp  DateTime64(3, 'UTC') CODEC (Delta, ZSTD(1)),
     traceID    String CODEC (ZSTD(1)),
     service    LowCardinality(String) CODEC (ZSTD(1)),
     operation  LowCardinality(String) CODEC (ZSTD(1)),

--- a/sqlscripts/jaeger-spans-archive.tmpl.sql
+++ b/sqlscripts/jaeger-spans-archive.tmpl.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS {{.SpansArchiveTable}}
     {{if .Multitenant -}}
     tenant    LowCardinality(String) CODEC (ZSTD(1)),
     {{- end -}}
-    timestamp DateTime CODEC (Delta, ZSTD(1)),
+    timestamp DateTime64(3, 'UTC') CODEC (Delta, ZSTD(1)),
     traceID   String CODEC (ZSTD(1)),
     model     String CODEC (ZSTD(3))
 ) ENGINE {{if .Replication}}ReplicatedMergeTree{{else}}MergeTree(){{end}}

--- a/sqlscripts/jaeger-spans.tmpl.sql
+++ b/sqlscripts/jaeger-spans.tmpl.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS {{.SpansTable}}
     {{if .Multitenant -}}
     tenant    LowCardinality(String) CODEC (ZSTD(1)),
     {{- end -}}
-    timestamp DateTime CODEC (Delta, ZSTD(1)),
+    timestamp DateTime64(3, 'UTC') CODEC (Delta, ZSTD(1)),
     traceID   String CODEC (ZSTD(1)),
     model     String CODEC (ZSTD(3))
 ) ENGINE {{if .Replication}}ReplicatedMergeTree{{else}}MergeTree(){{end}}

--- a/storage/store.go
+++ b/storage/store.go
@@ -220,7 +220,7 @@ func runInitScripts(logger hclog.Logger, db *sql.DB, cfg Configuration) error {
 		ttlDate       string
 	)
 	if cfg.TTLDays > 0 {
-		ttlTimestamp = fmt.Sprintf("TTL timestamp + INTERVAL %d DAY DELETE", cfg.TTLDays)
+		ttlTimestamp = fmt.Sprintf("TTL toDateTime(timestamp) + INTERVAL %d DAY DELETE", cfg.TTLDays)
 		ttlDate = fmt.Sprintf("TTL date + INTERVAL %d DAY DELETE", cfg.TTLDays)
 	}
 	if cfg.InitSQLScriptsDir != "" {


### PR DESCRIPTION
## Which problem is this PR solving?
- Uses millisecond-precision UTC timestamp instead of 'unspecified' DateTime

## Short description of the changes
- Changes timestamp column type from `DateTime` to DateTime64(3,'UTC')`
- This improves precision of spans, and allows for the database to have a non-default timezone without weird UI-backend interactions
